### PR TITLE
TodoList Search Items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,8 @@ mod tests {
         compare_items(&item2, &items[*ind2]);
     }
 
+    // doesn't actually test anything, just times the search function
+    // should be run with the --nocapture argument to actually show stdout
     #[test]
     fn timing_test() {
         let (_, mut list) = setup_search_tests(false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,38 @@ impl TodoList {
         due_in_less_than: Option<Duration>,
         urgency_at_least: Option<Urgency>,
         urgency_at_most: Option<Urgency>,
-    ) -> Vec<(usize, Item)> {
-        todo!("Insert code here to search for items based on given criteria.")
+    ) -> Vec<(usize, &Item)> {
+        let x: Vec<(usize, &Item)> = self.items.iter().enumerate().filter(|(_, item)| {
+            let flag1 = if let Some(u) = urgency_at_least.clone() { 
+                item.urgency >= u 
+            } else { false };
+
+            let flag2 = if let Some(u) = urgency_at_most.clone() {
+                item.urgency <= u
+            } else { false };
+
+            let flag3 = if let Some(t) = text_substr.clone() {
+                item.text == t 
+            } else { false };
+
+            let flag4 = if let Some(c) = checked.clone() {
+                item.checked == c
+            } else { false };
+
+            let flag5 = if let Some(d) = due_in_less_than.clone() {
+                let date = chrono::offset::Utc::now();
+                if let Some(ida) = item.due_at {
+                    (ida - date) <= d
+                } else { false }
+            } else { false };
+
+            return flag1 || flag2 || flag3 || flag4 || flag5;
+        }).collect();
+        
+        let v: Vec<(usize, &Item)> = vec![];
+        let x: Vec<&Item> = self.items.iter().filter(|item| text_substr.as_ref().map_or(true, |substr| { item.text.contains(substr) })).into_iter().collect();
+
+        return v;
     }
 
     /// Sets whether a to-do item is checked off.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,9 +130,6 @@ mod tests {
                 urgency: Urgency::Low   
             };
     
-            // let offset = if let Some(d) = Duration::seconds(1000000) { d 
-            // } else { panic!("Invalid Date Returned: exiting test") }; 
-    
             let item2 = Item {
                 text: String::from("I am item2!"),
                 checked: true,
@@ -329,5 +326,25 @@ mod tests {
         assert!(*ind1 == 0 && *ind2 == 2);
         compare_items(&item1, &items[*ind1]);
         compare_items(&item2, &items[*ind2]);
+    }
+
+    #[test]
+    fn timing_test() {
+        let (_, mut list) = setup_search_tests(false);
+        for i in 1..1_000_000 {
+            list.add_full_item(&Item {
+                text: format!("I am item {i}!"),
+                checked: true,
+                due_at: None,
+                urgency: Urgency::Normal
+            })
+        }
+
+        let before = Utc::now();
+        list.search(None, Some(true), None, None, None);
+        let after = Utc::now();
+
+        let diff = (after - before).num_milliseconds();
+        println!("Duration: {diff}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,6 @@ pub enum Urgency {
     High,
 }
 
-#[test]
-fn urgency_ord_does_the_right_thing() {
-    assert!(Urgency::High > Urgency::Normal);
-    assert!(Urgency::Normal > Urgency::Low);
-}
-
 /// The entire to-do list.
 #[derive(Debug, Default)]
 pub struct TodoList {
@@ -42,6 +36,10 @@ impl TodoList {
     /// Returns a new, empty to-do list.
     pub fn new() -> TodoList {
         TodoList::default()
+    }
+
+    pub fn add_full_item(&mut self, item: &Item) {
+        self.items.push(item.clone());
     }
 
     /// Adds a new item with default settings to the to-do list.
@@ -74,38 +72,18 @@ impl TodoList {
         due_in_less_than: Option<Duration>,
         urgency_at_least: Option<Urgency>,
         urgency_at_most: Option<Urgency>,
-    ) -> Vec<(usize, &Item)> {
-        let x: Vec<(usize, &Item)> = self.items.iter().enumerate().filter(|(_, item)| {
-            let flag1 = if let Some(u) = urgency_at_least.clone() { 
-                item.urgency >= u 
-            } else { false };
-
-            let flag2 = if let Some(u) = urgency_at_most.clone() {
-                item.urgency <= u
-            } else { false };
-
-            let flag3 = if let Some(t) = text_substr.clone() {
-                item.text == t 
-            } else { false };
-
-            let flag4 = if let Some(c) = checked.clone() {
-                item.checked == c
-            } else { false };
-
-            let flag5 = if let Some(d) = due_in_less_than.clone() {
-                let date = chrono::offset::Utc::now();
-                if let Some(ida) = item.due_at {
-                    (ida - date) <= d
-                } else { false }
-            } else { false };
-
-            return flag1 || flag2 || flag3 || flag4 || flag5;
-        }).collect();
-        
-        let v: Vec<(usize, &Item)> = vec![];
-        let x: Vec<&Item> = self.items.iter().filter(|item| text_substr.as_ref().map_or(true, |substr| { item.text.contains(substr) })).into_iter().collect();
-
-        return v;
+    ) -> Vec<(usize, Item)> {
+        self.items.iter().enumerate().filter(|(_, item)| {
+            (urgency_at_least.is_some() && // Some > None, add this check
+             Some(&item.urgency) >= urgency_at_least.as_ref()) ||
+            // no need to worry about is_some check as Some > None
+            Some(&item.urgency) <= urgency_at_most.as_ref() ||
+            Some(&item.text) == text_substr.as_ref() ||
+            Some(&item.checked) == checked.as_ref() ||
+            item.due_at.map_or(false, 
+                |date| Some(date - Utc::now()) <= due_in_less_than
+            ) 
+        }).map(|(ind, item)| (ind, (*item).clone())).collect()
     }
 
     /// Sets whether a to-do item is checked off.
@@ -126,5 +104,230 @@ impl TodoList {
     /// Sets how urgent a to-do item is.
     pub fn set_urgent(&mut self, index: usize, urgency: Urgency) {
         todo!("Insert code here to set the urgency of an item.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /* urgency tests */
+    #[test]
+    fn urgency_ord_does_the_right_thing() {
+        assert!(Urgency::High > Urgency::Normal);
+        assert!(Urgency::Normal > Urgency::Low);
+    }
+
+    /* search tests */
+    fn setup_search_tests(add: bool) -> (Vec<Item>, TodoList) {
+        let mut list = TodoList::new();
+        let mut item_vec: Vec<Item> = vec![];
+        if add {
+            let item1 = Item { 
+                text: String::from("I am item1!"),
+                checked: false,
+                due_at: None,
+                urgency: Urgency::Low   
+            };
+    
+            // let offset = if let Some(d) = Duration::seconds(1000000) { d 
+            // } else { panic!("Invalid Date Returned: exiting test") }; 
+    
+            let item2 = Item {
+                text: String::from("I am item2!"),
+                checked: true,
+                due_at: Some(Utc::now() + Duration::seconds(100000)), // 27 hours roughly
+                urgency: Urgency::High
+            };
+    
+            let item3 = Item {
+                text: String::from("I am item3!"),
+                checked: false,
+                due_at: None,
+                urgency: Urgency::Normal
+            };
+
+            item_vec.extend([item1, item2, item3]);
+            for item in item_vec.iter() {
+                list.add_full_item(&item);
+            }
+        };
+
+        (item_vec, list)
+    }
+
+    fn compare_items(item1: &Item, item2: &Item) {
+        assert!(item1.text == item2.text);
+        assert!(item1.urgency == item2.urgency);
+        assert!(item1.checked == item2.checked);
+        assert!(item1.due_at == item2.due_at);
+    }
+
+    fn compare_item_lists(list1: &Vec<(usize, Item)>, list2: &Vec<Item>) {
+        assert!(list1.len() == list2.len());
+        for (ind, item) in list1.iter() {
+            assert!(ind < &list2.len());
+            let act_item = &list2[*ind];
+            compare_items(item, act_item);
+        }
+    }
+
+    #[test]
+    fn none_search_on_empty_list_returns_nothing() {
+        let (_, list) = setup_search_tests(false);
+
+        let empty_list = list.search(None, None, None, None, None);
+
+        assert!(empty_list.len() == 0);
+    }
+
+    #[test]
+    fn non_none_search_on_empty_list_returns_nothing() {
+        let (_, list) = setup_search_tests(false);
+
+        let empty_list = list.search(
+            Some(String::from("nothing here!")), 
+            None, None, None, None
+        );
+
+        assert!(empty_list.len() == 0);
+    }
+
+    #[test]
+    fn none_search_on_full_list_returns_nothing() {
+        let (_, list) = setup_search_tests(true);
+
+        let empty_list = list.search(None, None, None, None, None);
+
+        assert!(empty_list.len() == 0);
+    }
+
+    #[test]
+    fn search_on_full_list_with_no_matchable_items_returns_nothing() {
+        let (_, list) = setup_search_tests(true);
+
+        let empty_list = list.search(
+            Some(String::from("nothing here!")),
+            None, None, None, None
+        );
+
+        assert!(empty_list.len() == 0);
+    }
+
+    #[test]
+    fn search_on_list_with_one_matching_item() {
+        let (items, list) = setup_search_tests(true);
+
+        let one_list = list.search(
+            Some(String::from("I am item1!")), 
+            None, None, None, None
+        );
+
+        assert!(one_list.len() == 1);
+        
+        let (ind, item) = &one_list[0];
+        let (act_ind, act_item) = (0, &items[0]);
+        assert!(*ind == act_ind);
+        compare_items(&item, act_item);
+    }
+
+    #[test]
+    fn search_on_list_matching_all() {
+        let (items, list) = setup_search_tests(true);
+
+        let all_list = list.search(
+            None, None, None, Some(Urgency::Low), Some(Urgency::High)
+        );
+
+        compare_item_lists(&all_list, &items);
+    }
+
+    #[test]
+    fn search_returned_values_arent_modified() {
+        let (_, list) = setup_search_tests(true);
+
+        let all_list = list.search(
+            None, None, None, Some(Urgency::Low), Some(Urgency::High)
+        );
+
+        compare_item_lists(&all_list, &list.items);
+    }
+
+    #[test]
+    fn search_on_string() {
+        let (items, list) = setup_search_tests(true);
+
+        let string_list = list.search(
+            Some(String::from("I am item2!")), None, None, None, None
+        );
+
+        assert!(string_list.len() == 1);
+        let (ind, item) = &string_list[0];
+        assert!(*ind < items.len());
+        assert!(*ind == 1);
+        compare_items(&item, &items[*ind]);
+    }
+
+    #[test]
+    fn search_on_checked() {
+        let (items, list) = setup_search_tests(true);
+
+        let checked_list = list.search(
+            None, Some(true), None, None, None
+        );
+
+        assert!(checked_list.len() == 1);
+        let (ind, item) = &checked_list[0];
+        assert!(*ind < items.len());
+        assert!(*ind == 1);
+        compare_items(&item, &items[*ind]);
+    }
+
+    #[test]
+    fn search_on_due_before() {
+        let (items, list) = setup_search_tests(true);
+
+        let due_list = list.search(
+            None, None, Some(Duration::seconds(200000)), None, None
+        );
+        assert!(due_list.len() == 1);
+        let (ind, item) = &due_list[0];
+        assert!(*ind < items.len());
+        assert!(*ind == 1);
+        compare_items(&item, &items[*ind]);
+    }
+
+    #[test]
+    fn search_on_least_urgency() {
+        let (items, list) = setup_search_tests(true);
+
+        let least_list = list.search(
+            None, None, None, Some(Urgency::Normal), None
+        );
+
+        assert!(least_list.len() == 2);
+        let (ind1, item1) = &least_list[0];
+        let (ind2, item2) = &least_list[1];
+        assert!(*ind1 < items.len() && *ind2 < items.len());
+        assert!(*ind1 == 1 && *ind2 == 2);
+        compare_items(&item1, &items[*ind1]);
+        compare_items(&item2, &items[*ind2]);
+    }
+
+    #[test]
+    fn search_on_most_urgency() {
+        let (items, list) = setup_search_tests(true);
+
+        let most_list = list.search(
+            None, None, None, None, Some(Urgency::Normal)
+        );
+
+        assert!(most_list.len() == 2);
+        let (ind1, item1) = &most_list[0];
+        let (ind2, item2) = &most_list[1];
+        assert!(*ind1 < items.len() && *ind2 < items.len());
+        assert!(*ind1 == 0 && *ind2 == 2);
+        compare_items(&item1, &items[*ind1]);
+        compare_items(&item2, &items[*ind2]);
     }
 }


### PR DESCRIPTION
# Overview

This PR implements the `TodoList::search()` function.
The `items` vector is filtered using comparisons between options,
leveraging the properties of comparing `Some()` to `None` to not 
use `if let` statements or more verbose methods.
Additionally, proper testing of the function was done for a variety
of circumstances, including a performance test in order to compare
against other versions other contributors may be working on.
To see output of the timing test, one can use the command:
```
cargo test timing_test -- --nocapture
```
A small `add_full_item()` function was also added to facilitate with testing.

One thing I was unsure on was the cloning of the items at the end of the search function.
Removing that cloning requires the function to return `Vec<(usize, &Item)>`
instead of `Vec<(usize, Item)>`. Is this a fair tradeoff to make? Is one or the other
considered better practice when writing rust code?

As always, feedback is appreciated!

\- Noah Hendrickson